### PR TITLE
codec: fix reference site and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The motivation behind this extension is to provide a standardized way to include
 | video:shape       | \[integer] | **REQUIRED**. Pixel dimensions of video, expressed as `[rows, columns]`                                                                      |
 | video:frame_rate  | number     | The mean frame rate, frames per second (frame count / time extent). Either `video:frame_rate` or `video:frame_count` are highly recommended. |
 | video:frame_count | integer    | The count of frames in the video. Either `video:frame_rate` or `video:frame_count` are highly recommended.                                   |
-| video:codec_name   | string     | Four-letter codec code ([list](https://www.fourcc.org/codecs.php))                                                                           |
+| video:codec_name  | string     | Four-letter codec code ([list](https://mp4ra.org/#/codecs#))                                                                           |
 
 ### Assets
 

--- a/examples/item.json
+++ b/examples/item.json
@@ -21,7 +21,7 @@
       1080,
       1920
     ],
-    "video:codec_name": "h264",
+    "video:codec_name": "avc1",
     "datetime": "2012-09-19T20:50:26.484970Z"
   },
   "geometry": {


### PR DESCRIPTION
The fourcc site that is referenced isn't very accurate and certainly not authoritative.

Also, the usual code for H.264 is "avc1".

We might yet need to consider whether the fourcc is really the right way to look this up (e.g. are people going to search for hev1 or avc3?), but this is a step closer.